### PR TITLE
add allow_with_resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ end
 This requires a method to be defined on `SomeCustomRoleObject` that checks if the role_resource object defined on the controller matches the user role. 
 
 
-```
+```ruby
 class SomeCustomRoleObject
   def resource?(resource)
     self.resources.includes?(resource)

--- a/README.md
+++ b/README.md
@@ -94,9 +94,12 @@ end
 ```
 
 # Allow roles with a resource
-`allow_with_resource` acts similarly to `allow` but requires a resource check to access the endpoint.
+`allow_with_resource` acts similarly to `allow` but executes a resource check on the `SomeCustomerRoleObject` to access the endpoint.
 
-This requires a method to be defined on `SomeCustomRoleObject` that checks if the role_resource object defined on the controller matches the user role. 
+This requires a method to be defined on `SomeCustomRoleObject` that checks if the resource is valid for that role.
+
+The `role_resource` needs to be defined on the controller to pass the resource that the role will be validated against.
+If `role_resource` is not defined it will be defaulted to an empty hash `{}`.
 
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ end
 ```
 
 # Allow roles with a resource
+`allow_with_resource` acts similarly to `allow` but requires a resource check to access the endpoint.
+
 This requires a method to be defined on `SomeCustomRoleObject` that checks if the role_resource object defined on the controller matches the user role. 
 
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,44 @@ class ProfilesController < ApplicationController
 end
 ```
 
+# Allow roles with a resource
+This requires a method to be defined on `SomeCustomRoleObject` that checks if the role_resource object defined on the controller matches the user role. 
+
+
+```
+class SomeCustomRoleObject
+  def resource?(resource)
+    self.resources.includes?(resource)
+  end
+end
+
+class ProfilesController < ApplicationController
+  allow_with_resource(:admin).to_access(:index)
+  allow_with_resource(:owner).to_access(:edit)
+  publicize(:show)
+
+  def index
+    current_roles # => [#<SomeCustomRoleObject to_role_string: "admin", resource?: true >]
+  end
+
+  def edit # Raises permission error before entering this
+    current_roles # => []
+  end
+
+  def show
+    current_roles # => []
+  end
+
+  private def current_user_roles
+    current_user.roles # => [#<SomeCustomRoleObject to_role_string: "admin", resource?: true>, #<SomeCustomRoleObject to_role_string: "scorekeeper", resource?: false>]
+  end
+
+  private def role_resource
+    { resource: params[:resource_id] }
+  end
+end
+```
+
 ## Contributing
 
 1. Fork it

--- a/lib/rolypoly/controller_role_dsl.rb
+++ b/lib/rolypoly/controller_role_dsl.rb
@@ -19,7 +19,7 @@ module Rolypoly
       end
 
       unless sub.method_defined? :role_resource
-        define_method(:role_resource) { [] }
+        define_method(:role_resource) { {} }
       end
       sub.send :extend, ClassMethods
     end

--- a/lib/rolypoly/controller_role_dsl.rb
+++ b/lib/rolypoly/controller_role_dsl.rb
@@ -68,15 +68,15 @@ module Rolypoly
 
     module ClassMethods
       def all_public
-        build_gatekeeper(nil, nil, false).all_public
+        build_gatekeeper(nil, nil).all_public
       end
 
       def restrict(*actions)
-        build_gatekeeper nil, actions, false
+        build_gatekeeper nil, actions
       end
 
       def allow(*roles)
-        build_gatekeeper roles, nil, false
+        build_gatekeeper roles, nil
       end
 
       def allow_with_resource(*roles)
@@ -98,7 +98,7 @@ module Rolypoly
         end
       end
 
-      def build_gatekeeper(roles, actions, require_resource)
+      def build_gatekeeper(roles, actions, require_resource = false)
         RoleGatekeeper.new(roles, actions, require_resource).tap { |gatekeeper|
           rolypoly_gatekeepers << gatekeeper
         }

--- a/lib/rolypoly/controller_role_dsl.rb
+++ b/lib/rolypoly/controller_role_dsl.rb
@@ -17,6 +17,10 @@ module Rolypoly
       unless sub.method_defined? :current_user_roles
         define_method(:current_user_roles) { [] }
       end
+
+      unless sub.method_defined? :role_resource
+        define_method(:role_resource) { [] }
+      end
       sub.send :extend, ClassMethods
     end
 
@@ -31,8 +35,8 @@ module Rolypoly
     def current_roles
       return [] if rolypoly_gatekeepers.empty?
       current_gatekeepers.reduce([]) { |array, gatekeeper|
-        if gatekeeper.role? current_user_roles
-          array += Array(gatekeeper.allowed_roles(current_user_roles, action_name))
+        if gatekeeper.role?(current_user_roles, role_resource)
+          array += Array(gatekeeper.allowed_roles(current_user_roles, action_name, role_resource))
         end
         array
       }
@@ -52,7 +56,7 @@ module Rolypoly
     def rolypoly_role_access?
       rolypoly_gatekeepers.empty? ||
         rolypoly_gatekeepers.any? { |gatekeeper|
-          gatekeeper.allow? current_roles, action_name
+          gatekeeper.allow?(current_roles, action_name, role_resource)
         }
     end
     private :rolypoly_role_access?
@@ -64,15 +68,19 @@ module Rolypoly
 
     module ClassMethods
       def all_public
-        build_gatekeeper(nil, nil).all_public
+        build_gatekeeper(nil, nil, false).all_public
       end
 
       def restrict(*actions)
-        build_gatekeeper nil, actions
+        build_gatekeeper nil, actions, false
       end
 
       def allow(*roles)
-        build_gatekeeper roles, nil
+        build_gatekeeper roles, nil, false
+      end
+
+      def allow_with_resource(*roles)
+        build_gatekeeper roles, nil, true
       end
 
       def publicize(*actions)
@@ -90,8 +98,8 @@ module Rolypoly
         end
       end
 
-      def build_gatekeeper(roles, actions)
-        RoleGatekeeper.new(roles, actions).tap { |gatekeeper|
+      def build_gatekeeper(roles, actions, require_resource)
+        RoleGatekeeper.new(roles, actions, require_resource).tap { |gatekeeper|
           rolypoly_gatekeepers << gatekeeper
         }
       end

--- a/lib/rolypoly/role_gatekeeper.rb
+++ b/lib/rolypoly/role_gatekeeper.rb
@@ -32,14 +32,14 @@ module Rolypoly
       self.all_actions = true
     end
 
-    def allow?(current_roles, action, role_resource)
+    def allow?(current_roles, action, resource)
       action?(action) &&
-        role?(current_roles, role_resource)
+        role?(current_roles, resource)
     end
 
-    def allowed_roles(current_roles, action, role_resource)
+    def allowed_roles(current_roles, action, resource)
       return [] if public? || !action?(action)
-      match_roles(current_roles, role_resource)
+      match_roles(current_roles, resource)
     end
 
     def all_public
@@ -47,8 +47,8 @@ module Rolypoly
       self.all_actions = true
     end
 
-    def role?(check_roles, role_resource)
-      check_roles = filter_roles_by_resource(check_roles, role_resource)
+    def role?(check_roles, resource)
+      check_roles = filter_roles_by_resource(check_roles, resource)
       check_roles = Set.new sanitize_role_input(check_roles)
       public? || !(check_roles & roles).empty?
     end
@@ -69,8 +69,8 @@ module Rolypoly
     attr_accessor :public
     attr_accessor :require_resource
 
-    def match_roles(check_roles, role_resource)
-      check_roles = filter_roles_by_resource(check_roles, role_resource)
+    def match_roles(check_roles, resource)
+      check_roles = filter_roles_by_resource(check_roles, resource)
       check_roles.reduce([]) { |array, role_object|
         array << role_object if roles.include?(sanitize_role_object(role_object))
         array
@@ -78,10 +78,10 @@ module Rolypoly
     end
     private :match_roles
 
-    def filter_roles_by_resource(check_roles, role_resource)
+    def filter_roles_by_resource(check_roles, resource)
       return check_roles unless require_resource
       check_roles.select do |check_role|
-        check_role.respond_to?(:resource?) && check_role.resource?(role_resource)
+        check_role.respond_to?(:resource?) && check_role.resource?(resource)
       end
     end
     private :filter_roles_by_resource

--- a/lib/rolypoly/role_gatekeeper.rb
+++ b/lib/rolypoly/role_gatekeeper.rb
@@ -2,10 +2,10 @@ require 'set'
 module Rolypoly
   class RoleGatekeeper
     attr_reader :roles
-    def initialize(roles, actions, require_resouce)
+    def initialize(roles, actions, require_resource)
       self.roles = Set.new Array(roles).map(&:to_s)
       self.actions = Set.new Array(actions).map(&:to_s)
-      self.require_resouce = require_resouce
+      self.require_resource = require_resource
       self.all_actions = false
       self.public = false
     end
@@ -48,7 +48,7 @@ module Rolypoly
     end
 
     def role?(check_roles, role_resource)
-      check_roles = filter_roles_by_resource(check_roles, role_resource) if require_resouce
+      check_roles = filter_roles_by_resource(check_roles, role_resource)
       check_roles = Set.new sanitize_role_input(check_roles)
       public? || !(check_roles & roles).empty?
     end
@@ -67,10 +67,10 @@ module Rolypoly
     attr_accessor :actions
     attr_accessor :all_actions
     attr_accessor :public
-    attr_accessor :require_resouce
+    attr_accessor :require_resource
 
     def match_roles(check_roles, role_resource)
-      check_roles = filter_roles_by_resource(check_roles, role_resource) if require_resouce
+      check_roles = filter_roles_by_resource(check_roles, role_resource)
       check_roles.reduce([]) { |array, role_object|
         array << role_object if roles.include?(sanitize_role_object(role_object))
         array
@@ -79,6 +79,7 @@ module Rolypoly
     private :match_roles
 
     def filter_roles_by_resource(check_roles, role_resource)
+      return check_roles unless require_resource
       check_roles.select do |check_role|
         check_role.respond_to?(:resource?) && check_role.resource?(role_resource)
       end

--- a/lib/rolypoly/role_gatekeeper.rb
+++ b/lib/rolypoly/role_gatekeeper.rb
@@ -2,9 +2,10 @@ require 'set'
 module Rolypoly
   class RoleGatekeeper
     attr_reader :roles
-    def initialize(roles, actions)
+    def initialize(roles, actions, require_resouce)
       self.roles = Set.new Array(roles).map(&:to_s)
       self.actions = Set.new Array(actions).map(&:to_s)
+      self.require_resouce = require_resouce
       self.all_actions = false
       self.public = false
     end
@@ -31,14 +32,14 @@ module Rolypoly
       self.all_actions = true
     end
 
-    def allow?(current_roles, action)
+    def allow?(current_roles, action, role_resource)
       action?(action) &&
-        role?(current_roles)
+        role?(current_roles, role_resource)
     end
 
-    def allowed_roles(current_roles, action)
+    def allowed_roles(current_roles, action, role_resource)
       return [] if public? || !action?(action)
-      match_roles(current_roles)
+      match_roles(current_roles, role_resource)
     end
 
     def all_public
@@ -46,7 +47,8 @@ module Rolypoly
       self.all_actions = true
     end
 
-    def role?(check_roles)
+    def role?(check_roles, role_resource)
+      check_roles = filter_roles_by_resource(check_roles, role_resource) if require_resouce
       check_roles = Set.new sanitize_role_input(check_roles)
       public? || !(check_roles & roles).empty?
     end
@@ -65,14 +67,23 @@ module Rolypoly
     attr_accessor :actions
     attr_accessor :all_actions
     attr_accessor :public
+    attr_accessor :require_resouce
 
-    def match_roles(check_roles)
+    def match_roles(check_roles, role_resource)
+      check_roles = filter_roles_by_resource(check_roles, role_resource) if require_resouce
       check_roles.reduce([]) { |array, role_object|
         array << role_object if roles.include?(sanitize_role_object(role_object))
         array
       }
     end
     private :match_roles
+
+    def filter_roles_by_resource(check_roles, role_resource)
+      check_roles.select do |check_role|
+        check_role.respond_to?(:resource?) && check_role.resource?(role_resource)
+      end
+    end
+    private :filter_roles_by_resource
 
     def sanitize_role_input(role_objects)
       Array(role_objects).map { |r| sanitize_role_object(r) }

--- a/lib/rolypoly/role_gatekeeper.rb
+++ b/lib/rolypoly/role_gatekeeper.rb
@@ -79,7 +79,7 @@ module Rolypoly
     private :match_roles
 
     def filter_roles_by_resource(check_roles, resource)
-      return check_roles unless require_resource
+      return check_roles if check_roles.nil? || !require_resource
       check_roles.select do |check_role|
         check_role.respond_to?(:resource?) && check_role.resource?(resource)
       end

--- a/lib/rolypoly/version.rb
+++ b/lib/rolypoly/version.rb
@@ -1,3 +1,3 @@
 module Rolypoly
-  VERSION = "0.1.3"
+  VERSION = "0.2.0"
 end

--- a/spec/lib/rolypoly/controller_role_dsl_spec.rb
+++ b/spec/lib/rolypoly/controller_role_dsl_spec.rb
@@ -77,6 +77,55 @@ module Rolypoly
           end
         end
       end
+
+      describe "from allow_with_resource side" do
+        let(:controller_instance) { subject.new }
+        let(:admin_role) do
+          admin = RoleObject.new(:admin)
+          allow(admin).to receive(:resource?).and_return true
+          admin
+        end
+        let(:scorekeeper_role) { RoleObject.new(:scorekeeper) }
+        let(:current_user_roles) { [admin_role, scorekeeper_role] }
+        let(:role_resource) { {resource: 123} }
+        let(:check_access) { controller_instance.rolypoly_check_role_access! }
+
+        before do
+          subject.allow_with_resource(:admin).to_access(:index)
+          subject.publicize(:landing)
+          allow(controller_instance).to receive(:current_user_roles).and_return(current_user_roles)
+          allow(controller_instance).to receive(:action_name).and_return(action_name)
+          allow(controller_instance).to receive(:role_resource).and_return(action_name)
+        end
+
+        describe "#index" do
+          let(:action_name) { "index" }
+
+          it { expect(controller_instance).to_not be_public }
+          it { expect{ check_access }.not_to raise_error }
+          it { expect(controller_instance.current_roles).to eq([RoleObject.new(:admin)])}
+        end
+
+        describe "#show" do
+          let(:action_name) { "show" }
+          
+          it { expect{ check_access }.to raise_error(Rolypoly::FailedRoleCheckError)}
+          it { expect(controller_instance).to_not be_public }
+        end
+
+        describe "#landing" do
+          let(:action_name) { "landing" }
+
+          it { expect{ check_access }.not_to raise_error }
+
+          describe "with no role" do
+            let(:current_roles) { [] }
+
+            it { expect { check_access }.not_to raise_error }
+            it { expect(controller_instance).to be_public }
+          end
+        end
+      end
     end
   end
 end

--- a/spec/lib/rolypoly/controller_role_dsl_spec.rb
+++ b/spec/lib/rolypoly/controller_role_dsl_spec.rb
@@ -15,6 +15,7 @@ module Rolypoly
     subject { example_controller }
     it { should respond_to :restrict }
     it { should respond_to :allow }
+    it { should respond_to :allow_with_resource }
 
     describe "setting up with DSL" do
       describe "from allow side" do

--- a/spec/lib/rolypoly/controller_role_dsl_spec.rb
+++ b/spec/lib/rolypoly/controller_role_dsl_spec.rb
@@ -80,48 +80,45 @@ module Rolypoly
 
       describe "from allow_with_resource side" do
         let(:controller_instance) { subject.new }
-        let(:admin_role) do
-          admin = RoleObject.new(:admin)
-          allow(admin).to receive(:resource?).and_return true
-          admin
-        end
+        let(:admin_role) { RoleObject.new(:admin) }
         let(:scorekeeper_role) { RoleObject.new(:scorekeeper) }
         let(:current_user_roles) { [admin_role, scorekeeper_role] }
         let(:role_resource) { {resource: 123} }
-        let(:check_access) { controller_instance.rolypoly_check_role_access! }
+        let(:check_access!) { controller_instance.rolypoly_check_role_access! }
 
         before do
           subject.allow_with_resource(:admin).to_access(:index)
           subject.publicize(:landing)
+          allow(admin_role).to receive(:resource?).and_return true
           allow(controller_instance).to receive(:current_user_roles).and_return(current_user_roles)
           allow(controller_instance).to receive(:action_name).and_return(action_name)
-          allow(controller_instance).to receive(:role_resource).and_return(action_name)
+          allow(controller_instance).to receive(:role_resource).and_return(role_resource)
         end
 
         describe "#index" do
           let(:action_name) { "index" }
 
           it { expect(controller_instance).to_not be_public }
-          it { expect{ check_access }.not_to raise_error }
+          it { expect{ check_access! }.not_to raise_error }
           it { expect(controller_instance.current_roles).to eq([RoleObject.new(:admin)])}
         end
 
         describe "#show" do
           let(:action_name) { "show" }
-          
-          it { expect{ check_access }.to raise_error(Rolypoly::FailedRoleCheckError)}
+
+          it { expect{ check_access! }.to raise_error(Rolypoly::FailedRoleCheckError)}
           it { expect(controller_instance).to_not be_public }
         end
 
         describe "#landing" do
           let(:action_name) { "landing" }
 
-          it { expect{ check_access }.not_to raise_error }
+          it { expect{ check_access! }.not_to raise_error }
 
           describe "with no role" do
             let(:current_roles) { [] }
 
-            it { expect { check_access }.not_to raise_error }
+            it { expect { check_access! }.not_to raise_error }
             it { expect(controller_instance).to be_public }
           end
         end

--- a/spec/lib/rolypoly/role_gatekeeper_spec.rb
+++ b/spec/lib/rolypoly/role_gatekeeper_spec.rb
@@ -132,7 +132,7 @@ module Rolypoly
       end
 
       describe "resource matches" do
-        let(:resource) { {organization: 530} }
+        let(:resource) { {resource: 123} }
 
         before do
           allow(scorekeeper).to receive(:resource?).and_return true

--- a/spec/lib/rolypoly/role_gatekeeper_spec.rb
+++ b/spec/lib/rolypoly/role_gatekeeper_spec.rb
@@ -4,113 +4,144 @@ module Rolypoly
   describe RoleGatekeeper do
     let(:roles) { %w[admin scorekeeper] }
     let(:actions) { %w[index show] }
-    let(:role_resource) { [] }
+    let(:resource) { [] }
 
-    subject { described_class.new roles, actions, false }
+    context "resource not required" do
+      subject { described_class.new roles, actions, false }
 
-    shared_examples_for "allow should behave correctly" do
-      it "shouldn't auto-allow" do
-        expect(subject.allow?(nil, nil, role_resource)).to be false
-      end
-
-      it "should allow scorekeepr access to index" do
-        expect(subject.allow?([:scorekeeper], "index", role_resource)).to be true
-      end
-
-      it "should not allow scorekeepr access to edit" do
-        expect(subject.allow?([:scorekeeper], "edit", role_resource)).to be false
-      end
-
-      describe "all public" do
-        before do
-          subject.all_public
-        end
-
-        it "should allow whatever" do
-          expect(subject.allow?(nil, nil, role_resource)).to be true
-        end
-
-        it "should allow scorekeepr access to index" do
-          expect(subject.allow?([:scorekeeper], "index", role_resource)).to be true
-        end
-
-        it "should allow scorekeepr access to edit" do
-          expect(subject.allow?([:scorekeeper], "edit", role_resource)).to be true
-        end
-      end
-
-      describe "all roles" do
-        before do
-          subject.to_none
-        end
-
+      shared_examples_for "allow should behave correctly" do
         it "shouldn't auto-allow" do
-          expect(subject.allow?(nil, nil, role_resource)).to be false
+          expect(subject.allow?(nil, nil, resource)).to be false
         end
 
         it "should allow scorekeepr access to index" do
-          expect(subject.allow?([:janitor], "index", role_resource)).to be true
-          expect(subject.allow?([:admin], "index", role_resource)).to be true
+          expect(subject.allow?([:scorekeeper], "index", resource)).to be true
         end
 
-        it "to should not allow scorekeepr access to edit" do
-          expect(subject.allow?([:scorekeeper], "edit", role_resource)).to be false
-          expect(subject.allow?([:janitor], "edit", role_resource)).to be false
+        it "should not allow scorekeepr access to edit" do
+          expect(subject.allow?([:scorekeeper], "edit", resource)).to be false
+        end
+
+        describe "all public" do
+          before do
+            subject.all_public
+          end
+
+          it "should allow whatever" do
+            expect(subject.allow?(nil, nil, resource)).to be true
+          end
+
+          it "should allow scorekeepr access to index" do
+            expect(subject.allow?([:scorekeeper], "index", resource)).to be true
+          end
+
+          it "should allow scorekeepr access to edit" do
+            expect(subject.allow?([:scorekeeper], "edit", resource)).to be true
+          end
+        end
+
+        describe "all roles" do
+          before do
+            subject.to_none
+          end
+
+          it "shouldn't auto-allow" do
+            expect(subject.allow?(nil, nil, resource)).to be false
+          end
+
+          it "should allow scorekeepr access to index" do
+            expect(subject.allow?([:janitor], "index", resource)).to be true
+            expect(subject.allow?([:admin], "index", resource)).to be true
+          end
+
+          it "to should not allow scorekeepr access to edit" do
+            expect(subject.allow?([:scorekeeper], "edit", resource)).to be false
+            expect(subject.allow?([:janitor], "edit", resource)).to be false
+          end
+        end
+
+        describe "all actions" do
+          before do
+            subject.to_all
+          end
+
+          it "shouldn't auto-allow" do
+            expect(subject.allow?(nil, nil, resource)).to be false
+          end
+
+          it "should allow scorekeepr access to index" do
+            expect(subject.allow?([:scorekeeper], "index", resource)).to be true
+          end
+
+          it "shouldn't allow janitor access to any" do
+            expect(subject.allow?([:janitor], "index", resource)).to be false
+          end
+
+          it "should allow scorekeepr access to edit" do
+            expect(subject.allow?([:scorekeeper], "edit", resource)).to be true
+          end
         end
       end
+      it_should_behave_like "allow should behave correctly"
 
-      describe "all actions" do
+      describe "with only roles set" do
+        let(:actions) { [] }
+
         before do
-          subject.to_all
+          subject.to_access(:index, :show)
         end
 
-        it "shouldn't auto-allow" do
-          expect(subject.allow?(nil, nil, role_resource)).to be false
+        it_should_behave_like "allow should behave correctly"
+      end
+
+      describe "with only actions set" do
+        let(:roles) { [] }
+
+        before do
+          subject.to(:admin, :scorekeeper)
         end
 
-        it "should allow scorekeepr access to index" do
-          expect(subject.allow?([:scorekeeper], "index", role_resource)).to be true
+        it_should_behave_like "allow should behave correctly"
+      end
+
+      describe "with resource defined" do
+        let(:resource) { [organization: 123] }
+
+        before do
+          subject.to(:admin, :scorekeeper)
         end
 
-        it "shouldn't allow janitor access to any" do
-          expect(subject.allow?([:janitor], "index", role_resource)).to be false
-        end
-
-        it "should allow scorekeepr access to edit" do
-          expect(subject.allow?([:scorekeeper], "edit", role_resource)).to be true
-        end
+        it_should_behave_like "allow should behave correctly"
       end
     end
-    it_should_behave_like "allow should behave correctly"
 
-    describe "with only roles set" do
-      let(:actions) { [] }
-
-      before do
-        subject.to_access(:index, :show)
+    context "resource required" do
+      let(:scorekeeper) do
+        scorekeeper = double("scorekeeper")
+        allow(scorekeeper).to receive(:resource?).and_return false
+        allow(scorekeeper).to receive(:to_role_string).and_return "scorekeeper"
+        scorekeeper
       end
 
-      it_should_behave_like "allow should behave correctly"
-    end
+      subject { described_class.new roles, actions, true }
 
-    describe "with only actions set" do
-      let(:roles) { [] }
-
-      before do
-        subject.to(:admin, :scorekeeper)
+      describe "resource does not match" do
+        it { expect(subject.allow?(nil, nil, resource)).to be false }
+        it { expect(subject.allow?([scorekeeper], "index", resource)).to be false }
+        it { expect(subject.allow?([scorekeeper], "edit", resource)).to be false }
       end
 
-      it_should_behave_like "allow should behave correctly"
-    end
+      describe "resource matches" do
+        let(:resource) { {organization: 530} }
 
-    describe "with role_resource defined" do
-      let(:role_resource) { [organization: 123] }
+        before do
+          allow(scorekeeper).to receive(:resource?).and_return true
+        end
 
-      before do
-        subject.to(:admin, :scorekeeper)
+        it { expect(subject.allow?(nil, nil, resource)).to be false }
+        it { expect(subject.allow?([scorekeeper], "index", resource)).to be true }
+        it { expect(subject.allow?([scorekeeper], "edit", resource)).to be false }
       end
-
-      it_should_behave_like "allow should behave correctly"
     end
   end
 end

--- a/spec/lib/rolypoly/role_gatekeeper_spec.rb
+++ b/spec/lib/rolypoly/role_gatekeeper_spec.rb
@@ -4,7 +4,7 @@ module Rolypoly
   describe RoleGatekeeper do
     let(:roles) { %w[admin scorekeeper] }
     let(:actions) { %w[index show] }
-    let(:resource) { [] }
+    let(:resource) { {} }
 
     context "resource not required" do
       subject { described_class.new roles, actions, false }

--- a/spec/lib/rolypoly/role_gatekeeper_spec.rb
+++ b/spec/lib/rolypoly/role_gatekeeper_spec.rb
@@ -116,31 +116,31 @@ module Rolypoly
     end
 
     context "resource required" do
-      let(:scorekeeper) do
-        scorekeeper = double("scorekeeper")
-        allow(scorekeeper).to receive(:resource?).and_return false
-        allow(scorekeeper).to receive(:to_role_string).and_return "scorekeeper"
-        scorekeeper
-      end
+      let(:scorekeeper_role) { RoleObject.new(:scorekeeper) }
 
       subject { described_class.new roles, actions, true }
 
       describe "resource does not match" do
+        before do
+          allow(scorekeeper_role).to receive(:resource?).and_return false
+          allow(scorekeeper_role).to receive(:to_role_string).and_return "scorekeeper"
+        end 
+
         it { expect(subject.allow?(nil, nil, resource)).to be false }
-        it { expect(subject.allow?([scorekeeper], "index", resource)).to be false }
-        it { expect(subject.allow?([scorekeeper], "edit", resource)).to be false }
+        it { expect(subject.allow?([scorekeeper_role], "index", resource)).to be false }
+        it { expect(subject.allow?([scorekeeper_role], "edit", resource)).to be false }
       end
 
       describe "resource matches" do
         let(:resource) { {resource: 123} }
 
         before do
-          allow(scorekeeper).to receive(:resource?).and_return true
+          allow(scorekeeper_role).to receive(:resource?).and_return true
         end
 
         it { expect(subject.allow?(nil, nil, resource)).to be false }
-        it { expect(subject.allow?([scorekeeper], "index", resource)).to be true }
-        it { expect(subject.allow?([scorekeeper], "edit", resource)).to be false }
+        it { expect(subject.allow?([scorekeeper_role], "index", resource)).to be true }
+        it { expect(subject.allow?([scorekeeper_role], "edit", resource)).to be false }
       end
     end
   end

--- a/spec/lib/rolypoly/role_gatekeeper_spec.rb
+++ b/spec/lib/rolypoly/role_gatekeeper_spec.rb
@@ -4,20 +4,21 @@ module Rolypoly
   describe RoleGatekeeper do
     let(:roles) { %w[admin scorekeeper] }
     let(:actions) { %w[index show] }
+    let(:role_resource) { [] }
 
-    subject { described_class.new roles, actions }
+    subject { described_class.new roles, actions, false }
 
     shared_examples_for "allow should behave correctly" do
       it "shouldn't auto-allow" do
-        expect(subject.allow?(nil, nil)).to be false
+        expect(subject.allow?(nil, nil, role_resource)).to be false
       end
 
       it "should allow scorekeepr access to index" do
-        expect(subject.allow?([:scorekeeper], "index")).to be true
+        expect(subject.allow?([:scorekeeper], "index", role_resource)).to be true
       end
 
       it "should not allow scorekeepr access to edit" do
-        expect(subject.allow?([:scorekeeper], "edit")).to be false
+        expect(subject.allow?([:scorekeeper], "edit", role_resource)).to be false
       end
 
       describe "all public" do
@@ -26,15 +27,15 @@ module Rolypoly
         end
 
         it "should allow whatever" do
-          expect(subject.allow?(nil, nil)).to be true
+          expect(subject.allow?(nil, nil, role_resource)).to be true
         end
 
         it "should allow scorekeepr access to index" do
-          expect(subject.allow?([:scorekeeper], "index")).to be true
+          expect(subject.allow?([:scorekeeper], "index", role_resource)).to be true
         end
 
         it "should allow scorekeepr access to edit" do
-          expect(subject.allow?([:scorekeeper], "edit")).to be true
+          expect(subject.allow?([:scorekeeper], "edit", role_resource)).to be true
         end
       end
 
@@ -44,17 +45,17 @@ module Rolypoly
         end
 
         it "shouldn't auto-allow" do
-          expect(subject.allow?(nil, nil)).to be false
+          expect(subject.allow?(nil, nil, role_resource)).to be false
         end
 
         it "should allow scorekeepr access to index" do
-          expect(subject.allow?([:janitor], "index")).to be true
-          expect(subject.allow?([:admin], "index")).to be true
+          expect(subject.allow?([:janitor], "index", role_resource)).to be true
+          expect(subject.allow?([:admin], "index", role_resource)).to be true
         end
 
         it "to should not allow scorekeepr access to edit" do
-          expect(subject.allow?([:scorekeeper], "edit")).to be false
-          expect(subject.allow?([:janitor], "edit")).to be false
+          expect(subject.allow?([:scorekeeper], "edit", role_resource)).to be false
+          expect(subject.allow?([:janitor], "edit", role_resource)).to be false
         end
       end
 
@@ -64,19 +65,19 @@ module Rolypoly
         end
 
         it "shouldn't auto-allow" do
-          expect(subject.allow?(nil, nil)).to be false
+          expect(subject.allow?(nil, nil, role_resource)).to be false
         end
 
         it "should allow scorekeepr access to index" do
-          expect(subject.allow?([:scorekeeper], "index")).to be true
+          expect(subject.allow?([:scorekeeper], "index", role_resource)).to be true
         end
 
         it "shouldn't allow janitor access to any" do
-          expect(subject.allow?([:janitor], "index")).to be false
+          expect(subject.allow?([:janitor], "index", role_resource)).to be false
         end
 
         it "should allow scorekeepr access to edit" do
-          expect(subject.allow?([:scorekeeper], "edit")).to be true
+          expect(subject.allow?([:scorekeeper], "edit", role_resource)).to be true
         end
       end
     end
@@ -94,6 +95,16 @@ module Rolypoly
 
     describe "with only actions set" do
       let(:roles) { [] }
+
+      before do
+        subject.to(:admin, :scorekeeper)
+      end
+
+      it_should_behave_like "allow should behave correctly"
+    end
+
+    describe "with role_resource defined" do
+      let(:role_resource) { [organization: 123] }
 
       before do
         subject.to(:admin, :scorekeeper)


### PR DESCRIPTION
Description and Impact
----------------------
> Adds an allow_with_resource method that will require a resource check when accessing the endpoint. This will act exactly the same as allow except that the `CustomRoleObject` used will need a method that checks if the resource matches the role. A method `role_resource` will need to be defined on the controller to allow the passing of the resource object. 
Ex. 
```ruby
class SomeCustomRoleObject
  def resource?(resource)
    self.resources.includes?(resource)
  end
end

class ProfilesController < ApplicationController
  allow_with_resource(:admin).to_access(:index)
 
  ...

  private def role_resource
     { resource: params[:resource_id] }
  end
end
```


Deploy Plan
-----------
> Does Platform Operations need to know anything special about this deploy? Are migrations present?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
> Fill in scenarios below in checklist format.
> Consider Regression scenarios (did we break something else related to this change) in addition to Happy Path (testing the new feature directly).
> Evaluate the risk level and label accordingly and ensure the QA Plan matches the risk level!

* Clone this repo and switch to this branch. 
- Switch an existing rails app to point the rolypoly gem to this branch. 
- [ ] Verify your existing endpoints still work for permissions checks.
- [ ] Verify you can add an allow_by_resource and a role_resource controller and the role check is working. 