### PR TITLE
Add resource checking to rolypoly and extract DSL logic into RoleDSL and RoleGatekeepers

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,62 @@ And then execute:
 $> bundle
 ```
 
-## Usage
+## Custom Usage
+
+```ruby
+role_checker = Rolypoly.define_gatekeepers do
+  allow(:super_duper_admin).to_all
+  allow(:super_admin).on(:organization).to_all
+  allow(:admin).on(:team).to_access(:show, :update)
+end
+
+role_checker_options = {
+  organization: ['Organization', team.organization_id],
+  team: team
+}
+
+role_checker.allow?(role_objects, :destroy, role_checker_options)
+role_checker.allow?(role_objects, :destroy, role_checker_options)
+```
+
+## Policy Usage
+
+```ruby
+class TeamPolicy < Struct.new(:user, :team)
+
+  include Rolypoly::RoleDSL
+
+  allow(:super_duper_admin).to_all
+  allow(:super_admin).on(:organization).to_all
+  allow(:admin).on(:team).to_access(:show, :update)
+
+  def show?
+    allow?(:show)
+  end
+
+  def update?
+    allow?(:update)
+  end
+
+  def destroy?
+    allow?(:destroy)
+  end
+
+  def current_user_roles
+    current_user.role_assignments
+  end
+
+  def rolypoly_resource_map
+    {
+      organization: ['Organization', team.organization_id]
+      team: team
+    }
+  end
+
+end
+```
+
+## Controller Usage
 
 ```ruby
 class ApplicationController < ActionController::Base

--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ end
 
 This requires a method to be defined on `SomeCustomRoleObject` that checks if the resource is valid for that role.
 
-The `role_resource` needs to be defined on the controller to pass the resource that the role will be validated against.
-If `role_resource` is not defined it will be defaulted to an empty hash `{}`.
+The `rolypoly_resource_map` needs to be defined on the controller to pass the resources that the role will be validated against.
+If `rolypoly_resource_map` is not defined it will be defaulted to an empty hash `{}`.
 
 
 ```ruby
@@ -110,8 +110,8 @@ class SomeCustomRoleObject
 end
 
 class ProfilesController < ApplicationController
-  allow_with_resource(:admin).to_access(:index)
-  allow_with_resource(:owner).to_access(:edit)
+  allow(:admin).on(:organization).to_access(:index)
+  allow(:owner).on(:profile).to_access(:edit)
   publicize(:show)
 
   def index
@@ -130,8 +130,11 @@ class ProfilesController < ApplicationController
     current_user.roles # => [#<SomeCustomRoleObject to_role_string: "admin", resource?: true>, #<SomeCustomRoleObject to_role_string: "scorekeeper", resource?: false>]
   end
 
-  private def role_resource
-    { resource: params[:resource_id] }
+  private def rolypoly_resource_map
+    {
+      organization: ['Organization', tournament.org_id]
+      tournament: tournament
+    }
   end
 end
 ```

--- a/lib/rolypoly.rb
+++ b/lib/rolypoly.rb
@@ -1,2 +1,12 @@
 require "rolypoly/version"
 require 'rolypoly/controller_role_dsl'
+
+module Rolypoly
+
+  def self.define_gatekeepers(&block)
+    role_gatekeepers = RoleGatekeepers.new
+    role_gatekeepers.instance_eval(&block)
+    role_gatekeepers
+  end
+
+end

--- a/lib/rolypoly/controller_role_dsl.rb
+++ b/lib/rolypoly/controller_role_dsl.rb
@@ -4,8 +4,6 @@ module Rolypoly
   FailedRoleCheckError = Class.new StandardError
   module ControllerRoleDSL
 
-    include RoleDSL::InstanceMethods
-
     def self.included(sub)
       sub.before_filter(:rolypoly_check_role_access!) if sub.respond_to? :before_filter
       if sub.respond_to? :rescue_from
@@ -18,42 +16,44 @@ module Rolypoly
         end
       end
 
+      sub.send(:include, RoleDSL)
       sub.extend(ClassMethods)
+      sub.send(:include, InstanceMethods)
     end
 
-    def rolypoly_check_role_access!
-      failed_role_check! unless rolypoly_role_access?
-    end
+    module InstanceMethods
+      def rolypoly_check_role_access!
+        failed_role_check! unless rolypoly_role_access?
+      end
 
-    def failed_role_check!
-      raise Rolypoly::FailedRoleCheckError
-    end
+      def failed_role_check!
+        raise Rolypoly::FailedRoleCheckError
+      end
 
-    def current_roles
-      allowed_roles(action_name)
-    end
+      def current_roles
+        allowed_roles(action_name)
+      end
 
-    def public?
-      super(action_name)
-    end
+      def public?
+        super(action_name)
+      end
 
-    def current_gatekeepers
-      rolypoly_gatekeepers.select { |gatekeeper|
-        gatekeeper.action? action_name
-      }
-    end
+      def current_gatekeepers
+        rolypoly_gatekeepers.select { |gatekeeper|
+          gatekeeper.action? action_name
+        }
+      end
 
-    def allow?(options = {})
-      rolypoly_gatekeepers.allow?(current_roles, action_name, rolypoly_resource_map.merge(options))
-    end
+      def allow?(options = {})
+        rolypoly_gatekeepers.allow?(current_roles, action_name, rolypoly_resource_map.merge(options))
+      end
 
-    private def rolypoly_role_access?
-      allow?
+      private def rolypoly_role_access?
+        allow?
+      end
     end
 
     module ClassMethods
-      include RoleDSL::ClassMethods
-
       private def rolypoly_gatekeepers=(arry)
         @rolypoly_gatekeepers = Rolypoly::RoleGatekeepers.new(arry)
       end

--- a/lib/rolypoly/role_dsl.rb
+++ b/lib/rolypoly/role_dsl.rb
@@ -42,6 +42,7 @@ module Rolypoly
       extend Forwardable
 
       def inherited(subclass)
+        super
         subclass.instance_variable_set('@rolypoly_gatekeepers', rolypoly_gatekeepers.dup)
       end
 

--- a/lib/rolypoly/role_dsl.rb
+++ b/lib/rolypoly/role_dsl.rb
@@ -1,0 +1,56 @@
+require 'forwardable'
+require 'rolypoly/role_gatekeepers'
+
+module Rolypoly
+  module RoleDSL
+
+    def self.included(base)
+      base.extend(ClassMethods)
+      base.send(:include, InstanceMethods)
+    end
+
+    module InstanceMethods
+      extend Forwardable
+
+      def self.included(base)
+        unless base.method_defined?(:current_user_roles)
+          define_method(:current_user_roles) do
+            []
+          end
+        end
+
+        unless base.method_defined?(:rolypoly_resource_map)
+          define_method(:rolypoly_resource_map) do
+            {}
+          end
+        end
+      end
+
+      def_delegators 'self.class', :rolypoly_gatekeepers
+      def_delegators :rolypoly_gatekeepers, :public?
+
+      def allow?(action, options = {})
+        rolypoly_gatekeepers.allow?(current_user_roles, action, rolypoly_resource_map.merge(options))
+      end
+
+      def allowed_roles(action, options = {})
+        rolypoly_gatekeepers.allowed_roles(current_user_roles, action, rolypoly_resource_map.merge(options))
+      end
+    end
+
+    module ClassMethods
+      extend Forwardable
+
+      def inherited(subclass)
+        subclass.instance_variable_set('@rolypoly_gatekeepers', rolypoly_gatekeepers.dup)
+      end
+
+      def_delegators :rolypoly_gatekeepers, :all_public, :restrict, :allow, :allow?, :allowed_roles, :on, :public?, :publicize
+
+      def rolypoly_gatekeepers
+        @rolypoly_gatekeepers ||= Rolypoly::RoleGatekeepers.new
+      end
+    end
+
+  end
+end

--- a/lib/rolypoly/role_gatekeeper.rb
+++ b/lib/rolypoly/role_gatekeeper.rb
@@ -10,6 +10,11 @@ module Rolypoly
       self.public = false
     end
 
+    def initialize_copy(other)
+      @roles = @roles.dup
+      @actions = @actions.dup
+    end
+
     # on(resource).allow(*roles).to_access(*actions)
     def allow(*roles)
       to(*roles)

--- a/lib/rolypoly/role_gatekeeper.rb
+++ b/lib/rolypoly/role_gatekeeper.rb
@@ -2,12 +2,30 @@ require 'set'
 module Rolypoly
   class RoleGatekeeper
     attr_reader :roles
-    def initialize(roles, actions, require_resource)
+    def initialize(roles, actions, resource = nil)
       self.roles = Set.new Array(roles).map(&:to_s)
       self.actions = Set.new Array(actions).map(&:to_s)
-      self.require_resource = require_resource
+      self.resource = resource
       self.all_actions = false
       self.public = false
+    end
+
+    # on(resource).allow(*roles).to_access(*actions)
+    def allow(*roles)
+      to(*roles)
+      self
+    end
+
+    # on(resource).restrict(*actions).to(*roles)
+    def restrict(*actions)
+      to_access(*actions)
+      self
+    end
+
+    # allow(*roles).on(resource).to_access(*actions)
+    def on(resource)
+      self.resource = resource
+      self
     end
 
     # restrict(*actions).to *roles
@@ -32,14 +50,13 @@ module Rolypoly
       self.all_actions = true
     end
 
-    def allow?(current_roles, action, resource)
-      action?(action) &&
-        role?(current_roles, resource)
+    def allow?(current_roles, action, options = {})
+      action?(action) && role?(current_roles, options)
     end
 
-    def allowed_roles(current_roles, action, resource)
+    def allowed_roles(current_roles, action, options = {})
       return [] if public? || !action?(action)
-      match_roles(current_roles, resource)
+      match_roles(current_roles, options)
     end
 
     def all_public
@@ -47,10 +64,29 @@ module Rolypoly
       self.all_actions = true
     end
 
-    def role?(check_roles, resource)
-      check_roles = filter_roles_by_resource(check_roles, resource)
-      check_roles = Set.new sanitize_role_input(check_roles)
-      public? || !(check_roles & roles).empty?
+    def role?(check_roles, options = {})
+      return true if public?
+      required_resource = find_required_resource(options)
+
+      Array(check_roles).any? do |check_role|
+        allowed_role?(check_role) && allowed_resource?(check_role, required_resource)
+      end
+    end
+
+    private def require_resource?
+      !!resource
+    end
+
+    private def allowed_resource?(check_role, required_resource)
+      return true unless require_resource?
+
+      check_role.respond_to?(:resource?) && check_role.resource?(required_resource)
+    end
+
+    private def find_required_resource(options = {})
+      return resource unless %w(String Symbol).include?(resource.class.to_s)
+
+      options[resource]
     end
 
     def action?(check_actions)
@@ -67,44 +103,21 @@ module Rolypoly
     attr_accessor :actions
     attr_accessor :all_actions
     attr_accessor :public
-    attr_accessor :require_resource
+    attr_accessor :resource
 
-    def match_roles(check_roles, resource)
-      check_roles = filter_roles_by_resource(check_roles, resource)
-      check_roles.reduce([]) { |array, role_object|
-        array << role_object if roles.include?(sanitize_role_object(role_object))
-        array
-      }
-    end
-    private :match_roles
+    private def match_roles(check_roles, options = {})
+      required_resource = find_required_resource(options)
 
-    def filter_roles_by_resource(check_roles, resource)
-      return check_roles if check_roles.nil? || !require_resource
-      check_roles.select do |check_role|
-        check_role.respond_to?(:resource?) && check_role.resource?(resource)
+      Array(check_roles).select do |check_role|
+        allowed_role?(check_role) && allowed_resource?(check_role, required_resource)
       end
     end
-    private :filter_roles_by_resource
 
-    def sanitize_role_input(role_objects)
-      Array(role_objects).map { |r| sanitize_role_object(r) }
-    end
-    private :sanitize_role_input
+    private def allowed_role?(role_object)
+      role_string = role_object.respond_to?(:to_role_string) ? role_object.to_role_string : role_object.to_s
 
-    def sanitize_role_object(role_object)
-      role_object.respond_to?(:to_role_string) ? role_object.to_role_string : role_object.to_s
+      roles.include?(role_string.to_s)
     end
-    private :sanitize_role_object
-
-    def can_set_with_to?
-      roles.empty?
-    end
-    private :can_set_with_to?
-
-    def can_set_with_access_to?
-      actions.empty?
-    end
-    private :can_set_with_access_to?
 
     def all_actions?
       !!all_actions

--- a/lib/rolypoly/role_gatekeepers.rb
+++ b/lib/rolypoly/role_gatekeepers.rb
@@ -1,0 +1,54 @@
+require 'forwardable'
+require 'rolypoly/role_gatekeeper'
+
+module Rolypoly
+  class RoleGatekeepers
+
+    extend Forwardable
+    include Enumerable
+
+    def_delegators :build_gatekeeper, :all_public, :allow, :on, :restrict
+    def_delegators :@gatekeepers, :clear, :each, :empty?
+
+    def initialize(gatekeepers = [])
+      @gatekeepers = Array(gatekeepers)
+    end
+
+    def initialize_copy(other)
+      @gatekeepers = @gatekeepers.map(&:dup)
+    end
+
+    def publicize(*actions)
+      restrict(*actions).to_none
+    end
+
+    def allow?(role_objects, action, options = {})
+      return true if empty?
+
+      any? { |gatekeeper| gatekeeper.allow?(role_objects, action, options) }
+    end
+
+    def allowed_roles(role_objects, action, options = {})
+      return [] if empty?
+
+      reduce([]) do |allowed_role_objects, gatekeeper|
+        allowed_role_objects | gatekeeper.allowed_roles(role_objects, action, options)
+      end
+    end
+
+    def public?(action)
+      return true if empty?
+
+      any? do |gatekeeper|
+        gatekeeper.action?(action) && gatekeeper.public?
+      end
+    end
+
+    private def build_gatekeeper(roles = nil, actions = nil, resource = nil)
+      new_gatekeeper = RoleGatekeeper.new(roles, actions, resource)
+      @gatekeepers << new_gatekeeper
+      new_gatekeeper
+    end
+
+  end
+end

--- a/lib/rolypoly/version.rb
+++ b/lib/rolypoly/version.rb
@@ -1,3 +1,3 @@
 module Rolypoly
-  VERSION = "0.2.0"
+  VERSION = "1.0.0"
 end

--- a/spec/lib/rolypoly/controller_role_dsl_spec.rb
+++ b/spec/lib/rolypoly/controller_role_dsl_spec.rb
@@ -15,7 +15,7 @@ module Rolypoly
     subject { example_controller }
     it { should respond_to :restrict }
     it { should respond_to :allow }
-    it { should respond_to :allow_with_resource }
+    it { should respond_to :on }
 
     describe "setting up with DSL" do
       describe "from allow side" do
@@ -78,21 +78,21 @@ module Rolypoly
         end
       end
 
-      describe "from allow_with_resource side" do
+      describe "from on side" do
         let(:controller_instance) { subject.new }
         let(:admin_role) { RoleObject.new(:admin) }
         let(:scorekeeper_role) { RoleObject.new(:scorekeeper) }
         let(:current_user_roles) { [admin_role, scorekeeper_role] }
-        let(:role_resource) { {resource: 123} }
+        let(:rolypoly_resource_map) { { organization: ['Organization', 123] } }
         let(:check_access!) { controller_instance.rolypoly_check_role_access! }
 
         before do
-          subject.allow_with_resource(:admin).to_access(:index)
+          subject.on(:organization).allow(:admin).to_access(:index)
           subject.publicize(:landing)
-          allow(admin_role).to receive(:resource?).and_return true
+          allow(admin_role).to receive(:resource?).with(rolypoly_resource_map[:organization]).and_return true
           allow(controller_instance).to receive(:current_user_roles).and_return(current_user_roles)
           allow(controller_instance).to receive(:action_name).and_return(action_name)
-          allow(controller_instance).to receive(:role_resource).and_return(role_resource)
+          allow(controller_instance).to receive(:rolypoly_resource_map).and_return(rolypoly_resource_map)
         end
 
         describe "#index" do

--- a/spec/lib/rolypoly/controller_role_dsl_spec.rb
+++ b/spec/lib/rolypoly/controller_role_dsl_spec.rb
@@ -1,9 +1,5 @@
 require 'spec_helper'
-class RoleObject < Struct.new :name
-  def to_s
-    name.to_s
-  end
-end
+
 module Rolypoly
   describe ControllerRoleDSL do
     let(:example_controller) do

--- a/spec/lib/rolypoly/role_dsl_spec.rb
+++ b/spec/lib/rolypoly/role_dsl_spec.rb
@@ -1,0 +1,98 @@
+require 'spec_helper'
+
+module Rolypoly
+  describe RoleDSL do
+    subject do
+      Class.new do
+        include Rolypoly::RoleDSL
+      end
+    end
+    after { subject.instance_variable_set('@rolypoly_gatekeepers', nil) }
+
+    it { expect(subject).to respond_to :rolypoly_gatekeepers }
+
+    it { expect(subject).to respond_to :all_public }
+    it 'should delegate all_public to rolypoly_gatekeepers' do
+      expect(subject.rolypoly_gatekeepers).to receive(:all_public)
+      subject.all_public
+    end
+
+    it { expect(subject).to respond_to :allow }
+    it 'should delegate allow to rolypoly_gatekeepers' do
+      expect(subject.rolypoly_gatekeepers).to receive(:allow).with(:role_1, :role_2)
+      subject.allow(:role_1, :role_2)
+    end
+
+    it { expect(subject).to respond_to :allow? }
+    it 'should delegate allow? to rolypoly_gatekeepers' do
+      expect(subject.rolypoly_gatekeepers).to receive(:allow?).with([:admin, :org_admin], :index)
+      subject.allow?([:admin, :org_admin], :index)
+    end
+
+    it { expect(subject).to respond_to :allowed_roles }
+    it 'should delegate allowed_roles to rolypoly_gatekeepers' do
+      expect(subject.rolypoly_gatekeepers).to receive(:allowed_roles).with([:admin, :org_admin], :index)
+      subject.allowed_roles([:admin, :org_admin], :index)
+    end
+
+    it { expect(subject).to respond_to :on }
+    it 'should delegate on to rolypoly_gatekeepers' do
+      expect(subject.rolypoly_gatekeepers).to receive(:on).with(:organization)
+      subject.on(:organization)
+    end
+
+    it { expect(subject).to respond_to :publicize }
+    it 'should delegate publicize to rolypoly_gatekeepers' do
+      expect(subject.rolypoly_gatekeepers).to receive(:publicize).with(:index, :show)
+      subject.publicize(:index, :show)
+    end
+
+    it { expect(subject).to respond_to :public? }
+    it 'should delegate public? to rolypoly_gatekeepers' do
+      expect(subject.rolypoly_gatekeepers).to receive(:public?).with(:index)
+      subject.public?(:index)
+    end
+
+    it { expect(subject).to respond_to :restrict }
+    it 'should delegate restrict to rolypoly_gatekeepers' do
+      expect(subject.rolypoly_gatekeepers).to receive(:restrict).with(:index, :show)
+      subject.restrict(:index, :show)
+    end
+
+    describe 'instance' do
+      let(:example_object) { subject.new }
+
+      it { expect(example_object).to respond_to :current_user_roles }
+      it { expect(example_object).to respond_to :rolypoly_resource_map }
+
+      it { expect(example_object).to respond_to :rolypoly_gatekeepers }
+      it 'should delegate rolypoly_gatekeepers to self.class' do
+        expect(subject).to receive(:rolypoly_gatekeepers)
+        example_object.rolypoly_gatekeepers
+      end
+
+      it { expect(subject).to respond_to :public? }
+      it 'should delegate public? to rolypoly_gatekeepers' do
+        expect(subject.rolypoly_gatekeepers).to receive(:public?).with(:index)
+        subject.public?(:index)
+      end
+
+      %w(allow? allowed_roles).each do |method_name|
+        it { expect(example_object).to respond_to method_name }
+
+        it "should delegate #{method_name} to rolypoly_gatekeepers" do
+          current_user_roles = [:admin, :org_admin]
+          rolypoly_resource_map = { foo: :foo, bar: :bar }
+          options = { bar: :baz }
+
+          expect(example_object).to receive(:current_user_roles).and_return(current_user_roles)
+          expect(example_object).to receive(:rolypoly_resource_map).and_return(rolypoly_resource_map)
+          expect(example_object.rolypoly_gatekeepers).to receive(method_name).with(current_user_roles, :index, { foo: :foo, bar: :baz })
+
+          example_object.public_send(method_name, :index, options)
+        end
+      end
+    end
+
+  end
+end

--- a/spec/lib/rolypoly/role_gatekeeper_spec.rb
+++ b/spec/lib/rolypoly/role_gatekeeper_spec.rb
@@ -4,22 +4,21 @@ module Rolypoly
   describe RoleGatekeeper do
     let(:roles) { %w[admin scorekeeper] }
     let(:actions) { %w[index show] }
-    let(:resource) { {} }
 
     context "resource not required" do
-      subject { described_class.new roles, actions, false }
+      subject { described_class.new roles, actions }
 
       shared_examples_for "allow should behave correctly" do
         it "shouldn't auto-allow" do
-          expect(subject.allow?(nil, nil, resource)).to be false
+          expect(subject.allow?(nil, nil)).to be false
         end
 
         it "should allow scorekeepr access to index" do
-          expect(subject.allow?([:scorekeeper], "index", resource)).to be true
+          expect(subject.allow?([:scorekeeper], "index")).to be true
         end
 
         it "should not allow scorekeepr access to edit" do
-          expect(subject.allow?([:scorekeeper], "edit", resource)).to be false
+          expect(subject.allow?([:scorekeeper], "edit")).to be false
         end
 
         describe "all public" do
@@ -28,15 +27,15 @@ module Rolypoly
           end
 
           it "should allow whatever" do
-            expect(subject.allow?(nil, nil, resource)).to be true
+            expect(subject.allow?(nil, nil)).to be true
           end
 
           it "should allow scorekeepr access to index" do
-            expect(subject.allow?([:scorekeeper], "index", resource)).to be true
+            expect(subject.allow?([:scorekeeper], "index")).to be true
           end
 
           it "should allow scorekeepr access to edit" do
-            expect(subject.allow?([:scorekeeper], "edit", resource)).to be true
+            expect(subject.allow?([:scorekeeper], "edit")).to be true
           end
         end
 
@@ -46,17 +45,17 @@ module Rolypoly
           end
 
           it "shouldn't auto-allow" do
-            expect(subject.allow?(nil, nil, resource)).to be false
+            expect(subject.allow?(nil, nil)).to be false
           end
 
           it "should allow scorekeepr access to index" do
-            expect(subject.allow?([:janitor], "index", resource)).to be true
-            expect(subject.allow?([:admin], "index", resource)).to be true
+            expect(subject.allow?([:janitor], "index")).to be true
+            expect(subject.allow?([:admin], "index")).to be true
           end
 
           it "to should not allow scorekeepr access to edit" do
-            expect(subject.allow?([:scorekeeper], "edit", resource)).to be false
-            expect(subject.allow?([:janitor], "edit", resource)).to be false
+            expect(subject.allow?([:scorekeeper], "edit")).to be false
+            expect(subject.allow?([:janitor], "edit")).to be false
           end
         end
 
@@ -66,19 +65,19 @@ module Rolypoly
           end
 
           it "shouldn't auto-allow" do
-            expect(subject.allow?(nil, nil, resource)).to be false
+            expect(subject.allow?(nil, nil)).to be false
           end
 
           it "should allow scorekeepr access to index" do
-            expect(subject.allow?([:scorekeeper], "index", resource)).to be true
+            expect(subject.allow?([:scorekeeper], "index")).to be true
           end
 
           it "shouldn't allow janitor access to any" do
-            expect(subject.allow?([:janitor], "index", resource)).to be false
+            expect(subject.allow?([:janitor], "index")).to be false
           end
 
           it "should allow scorekeepr access to edit" do
-            expect(subject.allow?([:scorekeeper], "edit", resource)).to be true
+            expect(subject.allow?([:scorekeeper], "edit")).to be true
           end
         end
       end
@@ -118,11 +117,24 @@ module Rolypoly
     context "resource required" do
       let(:scorekeeper_role) { RoleObject.new(:scorekeeper) }
 
-      subject { described_class.new roles, actions, true }
+      subject { described_class.new roles, actions, :resource }
 
       describe "resource does not match" do
         before do
-          allow(scorekeeper_role).to receive(:resource?).and_return false
+          allow(scorekeeper_role).to receive(:resource?).with(nil).and_return false
+          allow(scorekeeper_role).to receive(:to_role_string).and_return 'scorekeeper'
+        end
+
+        it { expect(subject.allow?(nil, nil)).to be false }
+        it { expect(subject.allow?(scorekeeper_role, :index)).to be false }
+        it { expect(subject.allow?(scorekeeper_role, :edit)).to be false }
+      end
+
+      describe "resource does not match" do
+        let(:resource) { { resource: ['Organization', 123] } }
+
+        before do
+          allow(scorekeeper_role).to receive(:resource?).with(resource[:resource]).and_return false
           allow(scorekeeper_role).to receive(:to_role_string).and_return "scorekeeper"
         end 
 
@@ -132,10 +144,10 @@ module Rolypoly
       end
 
       describe "resource matches" do
-        let(:resource) { {resource: 123} }
+        let(:resource) { { resource: ['Organization', 123] } }
 
         before do
-          allow(scorekeeper_role).to receive(:resource?).and_return true
+          allow(scorekeeper_role).to receive(:resource?).with(resource[:resource]).and_return true
         end
 
         it { expect(subject.allow?(nil, nil, resource)).to be false }

--- a/spec/lib/rolypoly/role_gatekeepers_spec.rb
+++ b/spec/lib/rolypoly/role_gatekeepers_spec.rb
@@ -1,0 +1,153 @@
+require 'spec_helper'
+
+module Rolypoly
+  describe RoleGatekeepers do
+    subject { RoleGatekeepers.new }
+    after { subject.clear }
+
+    # DSL class methods
+    describe 'rule-building methods' do
+      it { should respond_to :all_public }
+      it { expect { subject.all_public }.to change { subject.to_a.size }.by(1) }
+      it 'should delegate all_public to a new gatekeeper' do
+        expect_any_instance_of(RoleGatekeeper).to receive(:all_public)
+        subject.all_public
+      end
+
+      it { should respond_to :allow }
+      it { expect { subject.allow(:role_1, :role_2) }.to change { subject.to_a.size }.by(1) }
+      it 'should delegate allow to a new gatekeeper' do
+        expect_any_instance_of(RoleGatekeeper).to receive(:allow).with(:role_1, :role_2)
+        subject.allow(:role_1, :role_2)
+      end
+
+      it { should respond_to :on }
+      it { expect { subject.on(:organization) }.to change { subject.to_a.size }.by(1) }
+      it 'should delegate on to a new gatekeeper' do
+        expect_any_instance_of(RoleGatekeeper).to receive(:on).with(:organization)
+        subject.on(:organization)
+      end
+
+      it { should respond_to :publicize }
+      it { expect { subject.publicize }.to change { subject.to_a.size }.by(1) }
+      it 'should delegate publicize to a new gatekeeper' do
+        newer_gatekeeper = instance_double('RoleGatekeeper', :newer_gatekeeper)
+        expect_any_instance_of(RoleGatekeeper).to receive(:restrict).with(:index, :show).and_return(newer_gatekeeper)
+        expect(newer_gatekeeper).to receive(:to_none)
+        subject.publicize(:index, :show)
+      end
+
+      it { should respond_to :restrict }
+      it { expect { subject.restrict(:index, :show) }.to change { subject.to_a.size }.by(1) }
+      it 'should delegate restrict to a new gatekeeper' do
+        expect_any_instance_of(RoleGatekeeper).to receive(:restrict).with(:index, :show)
+        subject.restrict(:index, :show)
+      end
+    end
+
+    # DSL instance methods
+    it { should respond_to :allow? }
+    it { should respond_to :allowed_roles }
+    it { should respond_to :public? }
+
+    # Array methods not included in Enumerable
+    it { should respond_to :clear }
+    it { should respond_to :empty? }
+
+    describe 'setting up with DSL' do
+      describe 'from allow side' do
+        let(:current_user_roles) { [RoleObject.new(:admin), RoleObject.new(:scorekeeper)] }
+        before do
+          subject.allow(:admin).to_access(:index)
+          subject.publicize(:landing)
+        end
+
+        describe '#index' do
+          let(:action_name) { 'index' }
+
+          it 'is not public' do
+            expect(subject).to_not be_public(action_name)
+          end
+
+          it 'allows admin access' do
+            expect(subject).to be_allow(current_user_roles, action_name)
+          end
+
+          it 'can get current_user_roles' do
+            expect(subject.allowed_roles(current_user_roles, action_name)).to eq([RoleObject.new(:admin)])
+          end
+        end
+
+        describe '#show' do
+          let(:action_name) { 'show' }
+          it 'disallows admin access' do
+            expect(subject).to_not be_allow(current_user_roles, action_name)
+          end
+
+          it 'is not public' do
+            expect(subject).to_not be_public(action_name)
+          end
+        end
+
+        describe '#landing' do
+          let(:action_name) { 'landing' }
+          it 'allows admin access' do
+            expect(subject).to be_allow(current_user_roles, action_name)
+          end
+
+          describe 'with no role' do
+            let(:current_user_roles) { [] }
+            it 'allows admin access' do
+              expect(subject).to be_allow(current_user_roles, action_name)
+            end
+
+            it 'is public' do
+              expect(subject).to be_public(action_name)
+            end
+          end
+        end
+      end
+
+      describe 'from on side' do
+        let(:admin_role) { RoleObject.new(:admin) }
+        let(:scorekeeper_role) { RoleObject.new(:scorekeeper) }
+        let(:current_user_roles) { [admin_role, scorekeeper_role] }
+        let(:rolypoly_resource_map) { { organization: ['Organization', 123] } }
+
+        before do
+          subject.on(:organization).allow(:admin).to_access(:index)
+          subject.publicize(:landing)
+          allow(admin_role).to receive(:resource?).with(rolypoly_resource_map[:organization]).and_return true
+        end
+
+        describe '#index' do
+          let(:action_name) { 'index' }
+
+          it { expect(subject).to_not be_public(action_name) }
+          it { expect(subject).to be_allow(current_user_roles, action_name, rolypoly_resource_map) }
+          it { expect(subject.allowed_roles(current_user_roles, action_name, rolypoly_resource_map)).to eq([RoleObject.new(:admin)])}
+        end
+
+        describe '#show' do
+          let(:action_name) { 'show' }
+
+          it { expect(subject).to_not be_allow(current_user_roles, action_name) }
+          it { expect(subject).to_not be_public(action_name) }
+        end
+
+        describe '#landing' do
+          let(:action_name) { 'landing' }
+
+          it { expect(subject).to be_allow(current_user_roles, action_name) }
+
+          describe 'with no role' do
+            let(:current_user_roles) { [] }
+
+            it { expect(subject).to be_allow(current_user_roles, action_name) }
+            it { expect(subject).to be_public(action_name) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,13 @@
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 require 'rolypoly'
+
+class RoleObject < Struct.new(:name)
+  def to_s
+    name.to_s
+  end
+end
+
 RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
   config.filter_run :focus


### PR DESCRIPTION
- Add resource checking to DSL using `on`
- Extract logic from ControllerRoleDSL mostly into RoleGatekeepers
- Add RoleDSL to be the more generic parent of ControllerRoleDSL

# QA
- [x] Elmer tests pass (with slight modifications)
- [x] Ngin tests pass
- [x] Ngin runs locally
- [x] [LOCAL] With only US permissions, Team Center will load for a platform_admin
- [x] [LOCAL] With only US permissions, Team Center will load for an org admin for the teams org
- [x] [LOCAL] With only US permissions, Team Center will NOT load for an org admin that is not the team's org
- [x] [LOCAL] Tournament/stat-ngin works