### PR TITLE
Return no roles if no gatekeepers

### DIFF
--- a/lib/rolypoly/controller_role_dsl.rb
+++ b/lib/rolypoly/controller_role_dsl.rb
@@ -31,6 +31,8 @@ module Rolypoly
       end
 
       def current_roles
+        return [] if rolypoly_gatekeepers.empty?
+
         allowed_roles(action_name)
       end
 

--- a/lib/rolypoly/version.rb
+++ b/lib/rolypoly/version.rb
@@ -1,3 +1,3 @@
 module Rolypoly
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end


### PR DESCRIPTION
Since Elmer is mixed in with many controllers that use a User that doesn't have role assignments method, I need to reinstate the original behavior at the controller dsl level so that the current_user_roles method is never executed if there are no gatekeepers

QA
- [x] NGIN Integration tests pass (failed before, no role_assignments method)
- [x] NGIN Functional tests pass (failed before, no role_assignments method)