### PR TITLE
Reverse conditional to prevent warnings in Rails 5

### DIFF
--- a/lib/rolypoly/controller_role_dsl.rb
+++ b/lib/rolypoly/controller_role_dsl.rb
@@ -5,12 +5,12 @@ module Rolypoly
   module ControllerRoleDSL
 
     def self.included(sub)
-      if sub.respond_to? :before_filter
-        sub.before_filter(:rolypoly_check_role_access!)
-      elsif sub.respond_to? :before_action
+      if sub.respond_to? :before_action
         sub.before_action(:rolypoly_check_role_access!)
+      elsif sub.respond_to? :before_filter
+        sub.before_filter(:rolypoly_check_role_access!)
       end
-        if sub.respond_to? :rescue_from
+      if sub.respond_to? :rescue_from
         sub.rescue_from(FailedRoleCheckError) do
           respond_to do |f|
             f.html { render plain: "Not Authorized", status: 401 }


### PR DESCRIPTION
What
----------------------
> Update conditional to reverse reference to `before_filter` as primary conditional. Causing warnings. Reversing will not change functionality, but should remove warnings as the code doesn't hit the second part of the conditional.

Why
----------------------
> Prep for Rails 5.1 in Postal Service.

Deploy Plan
-----------
> Nothing special.

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
* [Jira issue CPO-2407](https://sportngin.atlassian.net/browse/CPO-2407)

QA Plan
-------
- [ ] Tests Pass
- [ ] Build Succeeds
